### PR TITLE
chore: remove unused placeholder logo

### DIFF
--- a/assets/rabbitwatch-cp-logo.png
+++ b/assets/rabbitwatch-cp-logo.png
@@ -1,1 +1,0 @@
-PNG logo for RabbitWatch CP as described above.


### PR DESCRIPTION
Rimuove `assets/rabbitwatch-cp-logo.png` (47 byte, placeholder non referenziato da nessun file). Pulisce la struttura del repo.